### PR TITLE
PC-114 Re-work response from rest /namespace/names

### DIFF
--- a/catapult-sdk/src/plugins/namespace.js
+++ b/catapult-sdk/src/plugins/namespace.js
@@ -92,8 +92,7 @@ const namespacePlugin = {
 
 		builder.addSchema('namespaceNameTuple', {
 			namespaceId: ModelType.uint64,
-			name: ModelType.string,
-			parentId: ModelType.uint64
+			name: ModelType.string
 		});
 
 		builder.addSchema('mosaicNamesTuple', {

--- a/catapult-sdk/test/plugins/namespace_spec.js
+++ b/catapult-sdk/test/plugins/namespace_spec.js
@@ -96,8 +96,8 @@ describe('namespace plugin', () => {
 			expect(Object.keys(modelSchema['namespaceDescriptor.alias.empty']).length).to.equal(0);
 
 			// - namespaceNameTuple
-			expect(Object.keys(modelSchema.namespaceNameTuple).length).to.equal(3);
-			expect(modelSchema.namespaceNameTuple).to.contain.all.keys(['namespaceId', 'name', 'parentId']);
+			expect(Object.keys(modelSchema.namespaceNameTuple).length).to.equal(2);
+			expect(modelSchema.namespaceNameTuple).to.contain.all.keys(['namespaceId', 'name']);
 
 			// - register namespace
 			expect(Object.keys(modelSchema.registerNamespace).length).to.equal(Object.keys(modelSchema.transaction).length + 4);

--- a/rest/test/plugins/namespace/namespaceRoutes_spec.js
+++ b/rest/test/plugins/namespace/namespaceRoutes_spec.js
@@ -180,13 +180,14 @@ describe('namespace routes', () => {
 	});
 
 	describe('get namespace names by ids', () => {
-		const createParentId = parentId => ({ high_: 0, low_: parentId });
+		const createParentId = parentId => ([0, parentId]);
 
 		const createNamespace = (parentId, namespaceId) => ({
 			// 1. in db, parentId is only stored for child namespaces
 			// 2. db returns null instead of undefined when a document property is not present
 			parentId: undefined === parentId ? null : createParentId(parentId),
-			namespaceId: [0, namespaceId]
+			namespaceId: [0, namespaceId],
+			name: `${namespaceId}`
 		});
 
 		const Valid_Hex_String_Namespace_Ids = ['1234567890ABCDEF', 'ABCDEF0123456789'];
@@ -225,13 +226,7 @@ describe('namespace routes', () => {
 						expect(dbParamTuple.fieldsDescriptor).to.deep.equal({ id: 'namespaceId', name: 'name', parentId: 'parentId' });
 					});
 
-					// check response
-					let expectedPayload = [];
-					options.dbEntitiesGroupedByLevel.forEach(dbEntities => {
-						expectedPayload = expectedPayload.concat(dbEntities);
-					});
-
-					expect(response).to.deep.equal({ payload: expectedPayload, type: 'namespaceNameTuple' });
+					expect(response).to.deep.equal({ payload: options.expectedPayload, type: 'namespaceNameTuple' });
 				}
 			);
 		};
@@ -243,6 +238,7 @@ describe('namespace routes', () => {
 			dbEntitiesGroupedByLevel: [
 				[]
 			],
+			expectedPayload: [],
 			expectedNumDbQueries: 1
 		}));
 
@@ -252,6 +248,20 @@ describe('namespace routes', () => {
 			],
 			dbEntitiesGroupedByLevel: [
 				[createNamespace(undefined, 9), createNamespace(undefined, 5), createNamespace(undefined, 7)]
+			],
+			expectedPayload: [
+				{
+					name: '9',
+					namespaceId: createParentId(9)
+				},
+				{
+					name: '5',
+					namespaceId: createParentId(5)
+				},
+				{
+					name: '7',
+					namespaceId: createParentId(7)
+				}
 			],
 			expectedNumDbQueries: 1
 		}));
@@ -264,6 +274,24 @@ describe('namespace routes', () => {
 			dbEntitiesGroupedByLevel: [
 				[createNamespace(undefined, 9), createNamespace(12, 5), createNamespace(0, 3), createNamespace(16, 7)],
 				[createNamespace(undefined, 12), createNamespace(undefined, 0), createNamespace(undefined, 16)]
+			],
+			expectedPayload: [
+				{
+					name: '9',
+					namespaceId: createParentId(9)
+				},
+				{
+					name: '12.5',
+					namespaceId: createParentId(5)
+				},
+				{
+					name: '0.3',
+					namespaceId: createParentId(3)
+				},
+				{
+					name: '16.7',
+					namespaceId: createParentId(7)
+				}
 			],
 			expectedNumDbQueries: 2
 		}));
@@ -278,6 +306,20 @@ describe('namespace routes', () => {
 				[createNamespace(17, 9), createNamespace(12, 5), createNamespace(16, 7)],
 				[createNamespace(undefined, 12), createNamespace(25, 16), createNamespace(25, 17)],
 				[createNamespace(undefined, 25), createNamespace(undefined, 25)]
+			],
+			expectedPayload: [
+				{
+					name: '25.17.9',
+					namespaceId: createParentId(9)
+				},
+				{
+					name: '12.5',
+					namespaceId: createParentId(5)
+				},
+				{
+					name: '25.16.7',
+					namespaceId: createParentId(7)
+				}
 			],
 			expectedNumDbQueries: 3
 		}));

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2551,14 +2551,12 @@ components:
       - namespaceId
       - name
       properties:
-        parentId:
-          $ref: "#/components/schemas/UInt64DTO"
         namespaceId:
           $ref: "#/components/schemas/UInt64DTO"
         name:
           type: string
-          description: The name of the namespace.
-          example: cat
+          description: The full name of the namespace.
+          example: cat.currency
     AliasDTO:
       type: object
       required:


### PR DESCRIPTION
Changed response for /namespace/names
https://nemspfs.atlassian.net/browse/PC-114
Now it is
[
    {
        "namespaceId": [
            3294802500,
            2243684972
        ],
        "name": "cat.currency"
    }
]

Instead of
[
    {
        "namespaceId": [
            3127188303,
            2974383967
        ],
        "name": "cat"
    },
    {
        "namespaceId": [
            3294802500,
            2243684972
        ],
        "name": "currency",
        "parentId": [
            3127188303,
            2974383967
        ]
    }
]