### PR TITLE
PC-148 Rest server Too many open files

### DIFF
--- a/rest/test/connection/zmqService_spec.js
+++ b/rest/test/connection/zmqService_spec.js
@@ -119,7 +119,7 @@ describe('zmq service', () => {
 			return new Promise(resolve => {
 				service.on('block.close', () => {
 					// Assert: socket is already closed when event is raised
-					expect(service.zsocketCount()).to.equal(0);
+					expect(service.zsocketCount()).to.equal(1);
 
 					setTimeout(() => {
 						// - listeners are removed after short delay
@@ -206,7 +206,7 @@ describe('zmq service', () => {
 						zsocket.send(blockBuffers.generationHash, zmq.ZMQ_SNDMORE);
 						zsocket.send(blockBuffers.channelName, zmq.ZMQ_SNDMORE);
 						zsocket.send(blockBuffers.address);
-					}, 100);
+					}, 200);
 				});
 			});
 		});

--- a/rest/test/server/bootstrapper_spec.js
+++ b/rest/test/server/bootstrapper_spec.js
@@ -549,7 +549,7 @@ describe('server (bootstrapper)', () => {
 		// the tests are using custom `/ws/block*` routes
 
 		const ports = { server: 1234, mq: 7902 };
-		const delays = { publish: 50 };
+		const delays = { publish: 200 };
 
 		const createBlockBuffer = tag => Buffer.concat([
 			Buffer.of(0xC2, 0x00, 0x00, 0x00), // size

--- a/scripts/DockerRelease/README.md
+++ b/scripts/DockerRelease/README.md
@@ -2,7 +2,7 @@
 
 ```bash
 cd proximax-catapult-rest
-docker build -t proximax-catapult-rest -f ./scripts/DockerRelease/Dockerfile .
+docker build -t proximax-sirius-rest -f ./scripts/DockerRelease/Dockerfile .
 ```
 
 ## Run container


### PR DESCRIPTION
Changed work with zeromq socket.
Now we have one connection for all subscriptions, instead of one socket on each subcription.
We are storing all subscriptions in Map, and on event we find handler from this Map and call it.