### PR TITLE
PC-171 Try to improve performance of the rest server

### DIFF
--- a/rest/resources/rest.json
+++ b/rest/resources/rest.json
@@ -26,6 +26,10 @@
     "timeout": 1000
   },
 
+  "transactionCache": {
+    "flushFrequency": 1500
+  },
+
   "websocket": {
     "mq": {
       "host": "127.0.0.1",

--- a/rest/src/plugins/routes/aggregateRoutes.js
+++ b/rest/src/plugins/routes/aggregateRoutes.js
@@ -32,14 +32,16 @@ module.exports = {
 			server,
 			services.connections,
 			{ routeName: '/transaction/partial', packetType: PacketType.pushPartialTransactions },
-			params => parseHexParam(params, 'payload')
+			params => parseHexParam(params, 'payload'),
+			services.transactionCache
 		);
 
 		routeUtils.addPutPacketRoute(
 			server,
 			services.connections,
 			{ routeName: '/transaction/cosignature', packetType: PacketType.pushDetachedCosignatures },
-			params => Buffer.concat(['signer', 'signature', 'parentHash'].map(key => parseHexParam(params, key)))
+			params => Buffer.concat(['signer', 'signature', 'parentHash'].map(key => parseHexParam(params, key))),
+			services.transactionCache
 		);
 	}
 };

--- a/rest/src/routes/transactionRoutes.js
+++ b/rest/src/routes/transactionRoutes.js
@@ -47,7 +47,8 @@ module.exports = {
 			server,
 			services.connections,
 			{ routeName: '/transaction', packetType: PacketType.pushTransactions },
-			params => routeUtils.parseArgument(params, 'payload', convert.hexToUint8)
+			params => routeUtils.parseArgument(params, 'payload', convert.hexToUint8),
+			services.transactionCache
 		);
 
 		routeUtils.addGetPostDocumentRoutes(

--- a/rest/src/server/transactionCache.js
+++ b/rest/src/server/transactionCache.js
@@ -1,0 +1,53 @@
+/**
+ *** Copyright 2019 ProximaX Limited. All rights reserved.
+ *** Use of this source code is governed by the Apache 2.0
+ *** license that can be found in the LICENSE file.
+ * */
+
+/**
+ * @param {object} transactionCacheConfig  of transaction cache.
+ * @param {object} connections Api server connection pool.
+ * @param {object} logger Logger.
+ * @returns {object} transaction cache
+ */
+module.exports.createTransactionCache = (transactionCacheConfig, connections, logger) => {
+	let cache;
+
+	cache = {
+		sending: false,
+		transactions: [],
+		sendTransactionToBlockchain: () => {
+			const temp = cache.transactions;
+			cache.transactions = [];
+
+			connections.lease().then(connection => {
+				connection.send(Buffer.concat(temp)).then(() => {
+					if (0 !== cache.transactions.length)
+						cache.sendTransactionToBlockchain();
+					else
+						cache.sending = false;
+				}).catch(() => {
+					logger(`got error during pushing ${temp.length} transactions`);
+					// if we got error during sending, let's add transactions back, and fire query again
+					cache.transactions = cache.transactions.concat(temp);
+					cache.sending = false;
+					cache.startTimer();
+				});
+			});
+		},
+
+		startTimer: () => {
+			if (!cache.sending) {
+				cache.sending = true;
+				setTimeout(cache.sendTransactionToBlockchain, transactionCacheConfig.flushFrequency);
+			}
+		},
+
+		addTransactionBuffer: transactionBuffer => {
+			cache.transactions.push(transactionBuffer);
+			cache.startTimer();
+		}
+	};
+
+	return cache;
+};

--- a/rest/test/server/transactionCache_spec.js
+++ b/rest/test/server/transactionCache_spec.js
@@ -1,0 +1,88 @@
+/**
+ *** Copyright 2019 ProximaX Limited. All rights reserved.
+ *** Use of this source code is governed by the Apache 2.0
+ *** license that can be found in the LICENSE file.
+ * */
+
+const catapultConnection = require('../../src/connection/catapultConnection');
+const { createTransactionCache } = require('../../src/server/transactionCache');
+const { expect } = require('chai');
+
+describe('transaction cache', () => {
+	const createTestContext = () => {
+		const context = {
+			onceCalls: {},
+			writeCalls: [],
+			mockConnection: {
+				once: (name, handler) => {
+					context.onceCalls[name] = handler;
+				},
+				removeListener: name => {
+					delete context.onceCalls[name];
+				},
+				write: (payload, callback) => {
+					context.writeCalls.push({ payload, callback });
+				}
+			}
+		};
+		return context;
+	};
+
+	describe('addTransactionBuffer', () => {
+		it('should add after timeout', () => {
+			const payload1 = Buffer.of(0x1);
+			const payload2 = Buffer.of(0x2);
+			const context = createTestContext();
+
+			// Act:
+			const connectionService = {
+				lease: () => new Promise(resolve => {
+					resolve(catapultConnection.wrap(context.mockConnection));
+				})
+			};
+
+			const config = {
+				flushFrequency: 1
+			};
+
+			const transactionCache = createTransactionCache(config, connectionService, () => {});
+			transactionCache.addTransactionBuffer(payload1);
+
+			expect(transactionCache.transactions.length).to.equal(1);
+			expect(context.writeCalls.length).to.equal(0);
+
+			setTimeout(() => {
+				// Assert:
+				expect(transactionCache.transactions.length).to.equal(0);
+				expect(context.writeCalls.length).to.equal(1);
+				expect(context.writeCalls[0].payload).to.deep.equal(payload1);
+				expect(context.onceCalls).to.have.all.keys('close');
+
+				// close socket
+				context.onceCalls.close();
+				setTimeout(() => {
+					// Assert:
+					expect(transactionCache.transactions.length).to.equal(1);
+					expect(transactionCache.transactions).to.deep.equal([payload1]);
+
+					setTimeout(() => {
+						// Assert:
+						expect(transactionCache.transactions.length).to.equal(0);
+						expect(context.writeCalls.length).to.equal(2);
+						expect(context.writeCalls[1].payload).to.deep.equal(payload1);
+
+						transactionCache.addTransactionBuffer(payload2);
+
+						expect(transactionCache.transactions.length).to.equal(1);
+						expect(transactionCache.transactions).to.deep.equal([payload2]);
+						context.writeCalls[1].callback();
+						setTimeout(() => {
+							// Assert:
+							expect(transactionCache.transactions.length).to.equal(0);
+						}, 1);
+					}, 200);
+				}, 1);
+			}, 100);
+		});
+	});
+});


### PR DESCRIPTION
Added transaction cache to improve performance of the rest server.
Now we are storing transactions in memory, and each second flush them to blockchain.
It frees connections with user and we can have more connections per second.