### PR TITLE
Send driveEvent to each drive instead only to latest

### DIFF
--- a/rest/src/connection/zmqUtils.js
+++ b/rest/src/connection/zmqUtils.js
@@ -110,16 +110,18 @@ module.exports = {
 	 * @param {function} zsocketFactory Factory for creating a zmq socket given a key.
 	 * @param {function} subcriptionInfoFactory Factory for creating a subcription info.
 	 * @param {object} logger It is logger=).
+	 * @param {function} resolver Topic's resolver.
 	 * @returns {object} Event emitter with partial interface (on, removeAllListeners, listenerCount).
 	 */
-	createMultisocketEmitter: (zsocketFactory, subcriptionInfoFactory, logger) => {
+	createMultisocketEmitter: (zsocketFactory, subcriptionInfoFactory, logger, resolver) => {
 		const emitter = new EventEmitter();
 		let zsocket = null;
 		const subscriptions = {};
 		const handlers = {};
 
-		function handle(topic) {
-			const handler = handlers[topic.toString()];
+		function handle(unresolvedTopic, buffer) {
+			const resolvedTopic = resolver ? resolver(unresolvedTopic, buffer) : unresolvedTopic;
+			const handler = handlers[resolvedTopic.toString()];
 
 			if (handler)
 				handler(...arguments);

--- a/rest/src/index.js
+++ b/rest/src/index.js
@@ -105,11 +105,11 @@ const registerRoutes = (server, db, services) => {
 	};
 
 	// 2. configure extension routes
-	const { transactionStates, messageChannelDescriptors } = routeSystem.configure(services.config.extensions, server, db, servicesView);
+	const { transactionStates, messageChannelDescriptors, messageChannelResolvers } = routeSystem.configure(services.config.extensions, server, db, servicesView);
 
 	// 3. augment services with extension-dependent config and services
 	servicesView.config.transactionStates = transactionStates;
-	servicesView.zmqService = createZmqConnectionService(services.config.websocket.mq, services.codec, messageChannelDescriptors, winston);
+	servicesView.zmqService = createZmqConnectionService(services.config.websocket.mq, services.codec, messageChannelDescriptors, messageChannelResolvers, winston);
 
 	// 4. configure basic routes
 	allRoutes.register(server, db, servicesView);

--- a/rest/src/plugins/routeSystem.js
+++ b/rest/src/plugins/routeSystem.js
@@ -71,7 +71,8 @@ module.exports = {
 
 		return {
 			transactionStates,
-			messageChannelDescriptors: messageChannelBuilder.build()
+			messageChannelDescriptors: messageChannelBuilder.build(),
+			messageChannelResolvers: messageChannelBuilder.buildResolvers()
 		};
 	}
 };

--- a/rest/test/connection/zmqService_spec.js
+++ b/rest/test/connection/zmqService_spec.js
@@ -40,7 +40,7 @@ describe('zmq service', () => {
 			host: '127.0.0.1', port: '3333', connectTimeout: 10, monitorInterval: 50
 		};
 		const channelDescriptors = new MessageChannelBuilder().build();
-		const service = createZmqConnectionService(zmqConfig, {}, channelDescriptors, test.createMockLogger());
+		const service = createZmqConnectionService(zmqConfig, {}, channelDescriptors, {}, test.createMockLogger());
 		cleanupActions.push(() => service.close());
 		return service;
 	};
@@ -161,7 +161,7 @@ describe('zmq service', () => {
 				deserialize: parser => parser.buffer(parser.numUnprocessedBytes())
 			};
 			const channelDescriptors = new MessageChannelBuilder().build();
-			const service = createZmqConnectionService(zmqConfig, codec, channelDescriptors, test.createLogger());
+			const service = createZmqConnectionService(zmqConfig, codec, channelDescriptors, {}, test.createLogger());
 			cleanupActions.push(() => service.close());
 
 			const blockBuffers = generateBlockBuffers();

--- a/rest/test/plugins/service_spec.js
+++ b/rest/test/plugins/service_spec.js
@@ -23,7 +23,11 @@ describe('service plugin', () => {
 		const registerAndExtractChannelDescriptor = channelDescriptorName => {
 			// Arrange:
 			const channelDescriptors = [];
-			const builder = { add: (name, markerChar, handler, channelFilter) => { channelDescriptors.push({ name, markerChar, handler, channelFilter }); } };
+			const channelResolvers = [];
+			const builder = {
+				add: (name, markerChar, handler, channelFilter) => { channelDescriptors.push({ name, markerChar, handler, channelFilter }); },
+				addResolver: (topic, resolver) => { channelResolvers.push({ topic, resolver }); }
+			};
 			const services = {
 				config: { network: { name: 'mijinTest' } }
 			};
@@ -34,7 +38,9 @@ describe('service plugin', () => {
 
 			// Sanity:
 			expect(channelDescriptors.length).to.equal(1);
+			expect(channelResolvers.length).to.equal(1);
 			expect(channelDescriptor).to.not.equal(undefined);
+			expect(channelResolvers).to.not.equal(undefined);
 			return channelDescriptor;
 		};
 
@@ -44,51 +50,7 @@ describe('service plugin', () => {
 
 			// Assert:
 			expect(descriptor.name).to.equal('driveState');
-			expect(descriptor.markerChar).to.equal('b');
-		});
-
-		it('handler emits nothing when receipt type invalid', () => {
-			// Arrange:
-			const emitted = [];
-			const { handler } = registerAndExtractChannelDescriptor('driveState');
-			const driveKey = test.random.publicKey();
-			const driveAddress = address.publicKeyToAddress(driveKey, networkInfo.networks.mijinTest.id);
-			const filter = addressToString(driveAddress);
-
-			// Act:
-			const buffer = Buffer.concat([
-				Buffer.of(0x5B, 0x0, 0x0, 0x0),
-				Buffer.of(0x5B, 0x0, 0x0, 0x0),
-				Buffer.of(0x0, 0x61),
-				driveKey,
-				Buffer.of(0x02)
-			]);
-			handler({}, eventData => emitted.push(eventData), filter)([0x01, 0x02], buffer, 'ignored data');
-
-			// Assert:
-			expect(emitted.length).to.equal(0);
-		});
-
-		it('handler emits nothing when drive address does not match filter', () => {
-			// Arrange:
-			const emitted = [];
-			const { handler } = registerAndExtractChannelDescriptor('driveState');
-			const driveKey = test.random.publicKey();
-			const driveAddress = test.random.address();
-			const filter = addressToString(driveAddress);
-
-			// Act:
-			const buffer = Buffer.concat([
-				Buffer.of(0x5B, 0x0, 0x0, 0x0),
-				Buffer.of(0x5B, 0x0, 0x0, 0x0),
-				Buffer.of(0x5B, 0x61),
-				driveKey,
-				Buffer.of(0x02)
-			]);
-			handler({}, eventData => emitted.push(eventData), filter)([0x01, 0x02], buffer, 'ignored data');
-
-			// Assert:
-			expect(emitted.length).to.equal(0);
+			expect(descriptor.markerChar).to.equal('d');
 		});
 
 		it('handler emits drive state', () => {
@@ -122,17 +84,6 @@ describe('service plugin', () => {
 					}
 				}
 			});
-		});
-
-		it('channel filter', () => {
-			// Arrange:
-			const { channelFilter } = registerAndExtractChannelDescriptor('driveState');
-
-			// Act:
-			const channelTopic = channelFilter()();
-
-			// Assert:
-			expect(channelTopic).to.deep.equal(Buffer.of(0x62));
 		});
 	});
 

--- a/rest/test/server/bootstrapper_spec.js
+++ b/rest/test/server/bootstrapper_spec.js
@@ -700,7 +700,7 @@ describe('server (bootstrapper)', () => {
 				host: '127.0.0.1', port: ports.mq, connectTimeout: 1000, monitorInterval: 50
 			};
 			const channelDescriptors = new MessageChannelBuilder().build();
-			const zmqService = createZmqConnectionService(config, modelSystem.codec, channelDescriptors, test.createMockLogger());
+			const zmqService = createZmqConnectionService(config, modelSystem.codec, channelDescriptors, {}, test.createMockLogger());
 
 			// create a custom emitter for raising client connected events
 			const emitter = new EventEmitter();


### PR DESCRIPTION
Added resolver logic which allow to resolve receipts into receipt of some type(For example drive state receipt), and after that extract some subscription info(like drive pub key).

Now for each drive event we will extract drive address and will call according to this address handler. When before we call handler of receipt topic, and notify only latest drive.