### PR TITLE
Fix Jenkins Build

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           sh '(cd catapult-sdk; yarn install; yarn run clean; yarn run build)'
 
           echo 'Building REST'
-          sh '(cd rest; yarn install)'
+          sh '(cd rest; yarn install; yarn run build)'
         }
       }
       post {


### PR DESCRIPTION
Jenkins is missing a `yarn run build`. v0.7.3 had a manual workaround but this should be applied before any future versions are released.