### PR TITLE
fix catapult-sdk unit tests

### DIFF
--- a/catapult-sdk/test/model/ModelFormatterBuilder_spec.js
+++ b/catapult-sdk/test/model/ModelFormatterBuilder_spec.js
@@ -180,7 +180,7 @@ describe('model formatter builder', () => {
 						{ id: 0, amount: 0 },
 						{ id: 0, amount: 0 }
 					],
-					supplementalAccountKeys: {
+					supplementalPublicKeys: {
 						linked: { publicKey: 0 },
 						node:  { publicKey: 0 },
 						vrf:  { publicKey: 0 },
@@ -206,7 +206,7 @@ describe('model formatter builder', () => {
 						{id: 'uint64', amount: 'uint64'},
 						{id: 'uint64', amount: 'uint64'}
 					],
-					supplementalAccountKeys: {
+					supplementalPublicKeys: {
 						linked: {
 							publicKey: "binary"
 						},

--- a/catapult-sdk/test/model/ModelSchemaBuilder_spec.js
+++ b/catapult-sdk/test/model/ModelSchemaBuilder_spec.js
@@ -83,7 +83,7 @@ describe('model schema builder', () => {
 				'transactionStatus',
 
 				'account',
-				"supplementalAccountKeys",
+				"supplementalPublicKeys",
 				"supplementalAccountKey",
 				'accountMeta',
 				"stakingRecord",
@@ -155,10 +155,10 @@ describe('model schema builder', () => {
 				'transactionWithMetadata.meta',
 				'transactionWithMetadata.transaction',
 				'transactionStatus.meta',
-				"account.supplementalAccountKeys",
-				"supplementalAccountKeys.linked",
-				"supplementalAccountKeys.node",
-				"supplementalAccountKeys.vrf",
+				"account.supplementalPublicKeys",
+				"supplementalPublicKeys.linked",
+				"supplementalPublicKeys.node",
+				"supplementalPublicKeys.vrf",
 				"stakingRecordWithMetadata.stakingAccount",
 
 				'accountWithMetadata.meta',


### PR DESCRIPTION
Replaced `supplementalAccountKeys` with `supplementalPublicKeys`